### PR TITLE
Add support to all color models and spaces

### DIFF
--- a/krita_batch_exporter/GDQuestBatchExporter.py
+++ b/krita_batch_exporter/GDQuestBatchExporter.py
@@ -39,7 +39,6 @@ def exportAllLayers(cfg, statusBar):
     msg, timeout = (cfg["done"]["msg"].format("Exported all layers."), cfg["done"]["timeout"])
     try:
         doc = KI.activeDocument()
-        ensureRGBAU8(doc)
 
         root = doc.rootNode()
         root = WNode(cfg, root)
@@ -57,7 +56,6 @@ def exportSelectedLayers(cfg, statusBar):
     msg, timeout = (cfg["done"]["msg"].format("Exported selected layers."), cfg["done"]["timeout"])
     try:
         doc = KI.activeDocument()
-        ensureRGBAU8(doc)
 
         dirName = os.path.dirname(doc.fileName())
         nodes = KI.activeWindow().activeView().selectedNodes()


### PR DESCRIPTION
This works by creating a temporary Document and invoking Krita's own `Document::setColorSpace` method. All color models and depths that Krita supports should now be supported in theory.

Output would still be 8bpc sRGB only.

This would incur some overhead associated with creation of the temporary `Document`, but I don't expect it to be very significant, since no view is created for it.