### PR TITLE
Fix wrong pykrita path on  MacOS

### DIFF
--- a/install-krita4.2.sh
+++ b/install-krita4.2.sh
@@ -88,7 +88,7 @@ main() {
 		uname -a | grep --quiet x86_64 || pillow_wheel=$WHEEL_LINUX_i686
 		;;
 	"darwin")
-		pykrita_dir="$HOME/.local/share/krita/pykrita"
+		pykrita_dir="/Users/$USER/Library/Application Support/krita/pykrita"
 		pillow_wheel=$WHEEL_MACOS
 		;;
 	"windowsnt" | "msys" | "mingw64_nt")


### PR DESCRIPTION
Pointing the installer to the correct pykrita path on Mac OS