### PR TITLE
Make pathFS work for a layer child of root on krita 4.3

### DIFF
--- a/krita_batch_exporter/Utils/Tree.py
+++ b/krita_batch_exporter/Utils/Tree.py
@@ -1,7 +1,6 @@
 import os
 from itertools import chain
 
-
 def iterPre(node, maxDepth=-1):
     """
     Visit nodes in pre order.
@@ -140,7 +139,7 @@ def pathFS(node):
     """
     it = filter(lambda n: n.parent, path(node))
     it = map(lambda n: n.name, it)
-    return os.path.join(*it)
+    return os.path.join('', *it) # In krita 4.3 it can be empty
 
 
 def iterDirs(node):


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [ x] The commit message follows our guidelines.
- For bug fixes and features:
    - [ x] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?** 
Krita 4.3 apparently changed the node tree so the first level nodes are not children of a 'root' node any more, this change avoids the error of calling `join` without arguments.

**Does this PR introduce a breaking change?**



## New feature or change ##


**What is the current behavior?** 



**What is the new behavior?**



**Other information**
