### PR TITLE
Add metadata inheritance from parent groups and option to not inherit the metadata

### DIFF
--- a/batch_exporter/Config.py
+++ b/batch_exporter/Config.py
@@ -8,6 +8,6 @@ CONFIG = {
     "error": {"msg": "ERROR: {}", "timeout": 8000},
     "done": {"msg": "DONE: {}", "timeout": 5000},
     "delimiters": OrderedDict((("assign", "="), ("separator", ","))),  # yapf: disable
-    "meta": {"c": [""], "e": ["png"], "m": [0], "p": [""], "t": [""], "s": [100]},
+    "meta": {"c": [""], "e": ["png"], "m": [0], "p": [""], "t": [""], "s": [100], "i": [""]},
 }
 CONFIG["sym"] = re.compile(CONFIG["sym"])

--- a/batch_exporter/Infrastructure.py
+++ b/batch_exporter/Infrastructure.py
@@ -248,7 +248,7 @@ class WNode:
                     else (r"$", r" {}{}{}".format(p[0], a, p[1]))
                     if how == "add"
                     else (
-                        r"\s*({}{})[\w,]+\s*".format(p[0], a),
+                        r"\s*({}{})[\w,/.]+\s*".format(p[0], a),
                         " " if how == "subtract" else r" \g<1>{} ".format(p[1]),
                     )
                 )

--- a/batch_exporter/Manual.md
+++ b/batch_exporter/Manual.md
@@ -21,6 +21,7 @@ the layer name. The supported options are:
   layer.
 - `[t=false]` or `[t=no]` - disable trimming the exported layer to the bounding box of
   the content.
+- `[i=false]` or `[i=no]` - disable parent metadata inheritance for a layer. More info [below](#layer-inheritance).
 
 A typical layer name with metadata looks like: `CharacterTorso e=png m=30 s=50,100`. This exports
 the layer as two images, with an added padding of 30 pixels on each side:
@@ -156,4 +157,50 @@ Root
   |    +-- Legs
   |
   Background
+```
+
+## Layer Inheritance
+
+Batch Exporter now allows child layers to inherit metadata from parent layers
+without the `e=` tag. This makes it easier to manage documents with lots of layers
+and results in cleaner looking layer names.
+
+Any layers tagged with `i=no` or `i=false` will not inherit metadata from their parent
+layers. Tagged group layers will still share **their own** metadata with their children.
+
+### Example
+
+Consider the following document structure:
+
+```
+Background e=png m=5 s=50,100 p=assets/images
+
+InterfaceGroupLayer
+  +-- ui_skin e=png m=5 s=50,100 p=assets/images/interface
+  +-- ui_skin_dark e=png m=5 s=50,100 p=assets/images/interface
+
+MapsGroupLayer
+  +-- map01 e=png p=assets/images/interface/maps
+  +-- map02 e=png p=assets/images/interface/maps
+
+MobsGroupLayer
+  +-- mob01 e=png,jpg m=10 s=75 p=assets/images/mobs
+  +-- mob02 e=png,jpg m=10 s=25 p=assets/images/mobs
+```
+
+Using metadata inheritance, you could achieve the above like so:
+
+```
+InterfaceGroupLayer m=5 s=50,100 p=assets/images/interface
+  +-- ui_skin e=png
+  +-- ui_skin_dark e=png
+  +-- Background e=png p=assets/images
+
+MapsGroupLayer p=assets/images/interface/maps
+  +-- map01 e=png
+  +-- map02 e=png
+
+MobsGroupLayer p=assets/images/mobs m=10
+  +-- mob01 e=png,jpg s=75
+  +-- mob02 e=png,jpg s=25
 ```

--- a/batch_exporter/batch_exporter.py
+++ b/batch_exporter/batch_exporter.py
@@ -126,7 +126,8 @@ class GameArtTools(DockWidget):
         exportSelectedLayersButton = QPushButton("Selected Layers")
         renameLabel = QLabel("Update Name and Metadata")
         renameLineEdit = QLineEdit()
-        renameButton = QPushButton("Update")
+        renameButton = QPushButton()
+        renameButton.setIcon(KI.icon("view-refresh"))
         statusBar = QStatusBar()
 
         exportLabel.setToolTip("Export individual images")
@@ -150,15 +151,15 @@ class GameArtTools(DockWidget):
 
         vboxlayout = QVBoxLayout()
         vboxlayout.addWidget(exportLabel)
+
         vboxlayout.addWidget(exportAllLayersButton)
         vboxlayout.addWidget(exportSelectedLayersButton)
 
         vboxlayout.addWidget(coaToolsGroupBox)
         vboxlayout.addWidget(renameLabel)
-        vboxlayout.addWidget(renameLineEdit)
 
         hboxlayout = QHBoxLayout()
-        hboxlayout.addStretch()
+        hboxlayout.addWidget(renameLineEdit)
         hboxlayout.addWidget(renameButton)
 
         vboxlayout.addLayout(hboxlayout)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [x] You updated the docs or changelog. (Only Manual.md, I don't know what tool to use to generate the html)


Related issue (if applicable):

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

Fixes bug #49 
Small UI change
Introduces a new feature

**Does this PR introduce a breaking change?**

Not 100% sure. But all my tests went as expected.

## New feature or change ##

Introduces a feature I call "metadata inheritance", which allows group layers that are **not** marked for export to share their metadata to child layers. Reduces the clutter in layer names and makes it easier to organize larger documents.

Introduced a new tag `i=no|false` which makes layers ignore all inherited metadata. Group Layers can still share their own defined metadata with their children when marked with `i=`.

**What is the current behavior?** 

Layers have to be multi selected to change, often similar, metadata.

**What is the new behavior?**

A single group layer can share common metadata tags to child layers while still allowing child layers to override those tags if needed.

**Other information**

Fixed #49
Changed the update button on the UI to be inline with the line edit and replaced the "Update" text with the "view-refresh" icon.