### PR TITLE
Change: Non-whole numbers for size/scale enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This document lists new features, improvements, changes, and bug fixes in each release of the package.
 
+## Krita Batch Exporter 1.1.2
+
+### Features
+- Float values now accepted as scales, e.g. `s=33.33`.
+
 ## Krita Batch Exporter 1.1.1
 
 ### Bug fixes

--- a/batch_exporter/Infrastructure.py
+++ b/batch_exporter/Infrastructure.py
@@ -101,7 +101,12 @@ class WNode:
 
             if len(data) == 2:
                 k, v = data[0], data[1].split(s)
-                meta[k] = list(map(int, v)) if k in "ms" else v
+                if k == "m":
+                    meta[k] = list(map(int, v))
+                elif k == "s":
+                    meta[k] = list(map(float, v))
+                else:
+                    meta[k] = v
 
         return meta
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [ ] The commit message follows our guidelines.
- For bug fixes and features:
    - [x ] You tested the changes.
    - [ x] You updated the docs or changelog.


Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

Feature fix

**Does this PR introduce a breaking change?**
No


## New feature or change ##
Splits up the line `meta[k] = list(map(int, v)) if k in "ms" else v` in `meta()` for the WNode class so that floats may be accepted as inputs for s (size/scale).

**What is the current behavior?** 
Attempting a scale tag with a non-whole number causes an error because int is expected for m (margin) and s(scale/size) values.


**What is the new behavior?**
Scale can be read as a float, and the dimensions are capped to whole numbers afterwards.


**Other information**
